### PR TITLE
Add CLI for summarising EDF files

### DIFF
--- a/EDFFile.js
+++ b/EDFFile.js
@@ -105,6 +105,11 @@ function parseSignalHeader(fileArray, fileData){
     return fileData;
 }
 
+// allow Node.js require
+if (typeof module !== 'undefined') {
+  module.exports = { parseEDFFile };
+}
+
 function parseSignals(fileArray, fileData){
 	for(const nextSignal of fileData.signals){
 		nextSignal.digitalValues = [];

--- a/FlowLimits.js
+++ b/FlowLimits.js
@@ -938,5 +938,17 @@ function formatChartDate(inDate){
 			twoCharLeadingZero( inDate.getHours() ) + ":" +
 			twoCharLeadingZero( inDate.getMinutes() ) + ":" + 
 			twoCharLeadingZero( inDate.getSeconds() ) + "." +
-			threeCharLeadingZero( inDate.getMilliseconds() );	
+                        threeCharLeadingZero( inDate.getMilliseconds() );
+}
+
+// allow Node.js require
+if (typeof module !== 'undefined') {
+  module.exports = {
+    formDataArray,
+    findMins,
+    findInspirations,
+    calcCycleBasedIndicators,
+    inspirationAmplitude,
+    prepIndices,
+  };
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# GlasgowIndex CLI
+
+This repository includes a script for summarising EDF files in a `DATALOG` directory.
+
+## Usage
+
+Place your EDF files under a folder named `DATALOG` at the project root. Files can be
+inside subfolders. Run the CLI with Node:
+
+```bash
+node cli/processDatalog.js
+```
+
+The script searches recursively for `*.edf` files, analyses each file and prints a
+table containing breathing indices for every recording.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ breathing indices:
 node cli/processDatalog.js /path/to/DATALOG
 ```
 
+If a file cannot be parsed it will be skipped and an error reported.
+
 Example output:
 
 ```

--- a/README.md
+++ b/README.md
@@ -4,12 +4,10 @@ This repository includes a script for summarising EDF files in a `DATALOG` direc
 
 ## Usage
 
-Place your EDF files under a folder named `DATALOG` at the project root. Files can be
-inside subfolders. Run the CLI with Node:
+Run the CLI passing the path to your `DATALOG` directory. The script will search
+recursively for `*_BRP.edf` files, analyse each one and print a table of
+breathing indices:
 
 ```bash
-node cli/processDatalog.js
+node cli/processDatalog.js /path/to/DATALOG
 ```
-
-The script searches recursively for `*.edf` files, analyses each file and prints a
-table containing breathing indices for every recording.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This repository includes a script for summarising EDF files in a `DATALOG` direc
 ## Usage
 
 Run the CLI passing the path to your `DATALOG` directory. The script searches
-recursively for `*_BRP.edf` files. As each file is processed a row is printed
-showing its breathing indices:
+recursively for `*_BRP.edf` files. Files are processed from newest to oldest and
+a row is printed as soon as each file finishes:
 
 ```bash
 node cli/processDatalog.js /path/to/DATALOG

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This repository includes a script for summarising EDF files in a `DATALOG` direc
 
 Run the CLI passing the path to your `DATALOG` directory. The script searches
 recursively for `*_BRP.edf` files. Files are processed from newest to oldest and
-a row is printed as soon as each file finishes:
+a row is printed as soon as each file finishes. The date and time are derived
+from the filename:
 
 ```bash
 node cli/processDatalog.js /path/to/DATALOG
@@ -17,7 +18,7 @@ If a file cannot be parsed it will be skipped and an error reported.
 Example output:
 
 ```
-date          overall    skew    flatTop    spike    topHeavy    multiPeak    noPause    inspirRate    multiBreath    ampVar
-----------  ---------  ------  ---------  -------  ----------  -----------  ---------  ------------  -------------  --------
-2025-06-10  0.23       0.10    0.05       0.00     0.02        0.03         0.01       12            0.00           0.02
+date          time      overall    skew    flatTop    spike    topHeavy    multiPeak    noPause    inspirRate    multiBreath    ampVar
+----------  --------  ---------  ------  ---------  -------  ----------  -----------  ---------  ------------  -------------  --------
+2025-06-10  22:20:47  0.23       0.10    0.05       0.00     0.02        0.03         0.01       12            0.00           0.02
 ```

--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ breathing indices:
 ```bash
 node cli/processDatalog.js /path/to/DATALOG
 ```
+
+Example output:
+
+```
+date          overall    skew    flatTop    spike    topHeavy    multiPeak    noPause    inspirRate    multiBreath    ampVar
+----------  ---------  ------  ---------  -------  ----------  -----------  ---------  ------------  -------------  --------
+2025-06-10  0.23       0.10    0.05       0.00     0.02        0.03         0.01       12            0.00           0.02
+```

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repository includes a script for summarising EDF files in a `DATALOG` direc
 
 ## Usage
 
-Run the CLI passing the path to your `DATALOG` directory. The script will search
-recursively for `*_BRP.edf` files, analyse each one and print a table of
-breathing indices:
+Run the CLI passing the path to your `DATALOG` directory. The script searches
+recursively for `*_BRP.edf` files. As each file is processed a row is printed
+showing its breathing indices:
 
 ```bash
 node cli/processDatalog.js /path/to/DATALOG

--- a/cli/processDatalog.js
+++ b/cli/processDatalog.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+'use strict';
 const fs = require('fs');
 const path = require('path');
 
@@ -26,7 +27,13 @@ async function processFile(filePath) {
   const buf = await readFileBuffer(filePath);
   const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
   const fileData = parseEDFFile(ab);
+  if (!fileData.signals || fileData.signals.length === 0) {
+    throw new Error('Invalid or empty EDF file');
+  }
   const dataArray = formDataArray(fileData);
+  if (!Array.isArray(dataArray) || dataArray.length === 0) {
+    throw new Error('No flow data found');
+  }
   findMins(dataArray);
   const results = {};
   findInspirations(dataArray, results);

--- a/cli/processDatalog.js
+++ b/cli/processDatalog.js
@@ -61,7 +61,29 @@ function findEdfFiles(dir) {
   return out;
 }
 
-function printTable(rows) {
+
+function printHeader(headers, colWidths) {
+  const headerRow = headers.map((h, i) => h.padEnd(colWidths[i])).join('  ');
+  const sep = headers.map((h, i) => '-'.repeat(colWidths[i])).join('  ');
+  console.log(headerRow);
+  console.log(sep);
+}
+
+function printRow(row, headers, colWidths) {
+  const line = headers
+    .map((h, i) => String(row[h]).padEnd(colWidths[i]))
+    .join('  ');
+  console.log(line);
+}
+
+async function main() {
+  const baseDir = process.argv[2] || path.join(__dirname, '..', 'DATALOG');
+  const files = findEdfFiles(baseDir);
+  if (files.length === 0) {
+    console.log('No EDF files found in', baseDir);
+    return;
+  }
+
   const headers = [
     'date',
     'overall',
@@ -75,33 +97,17 @@ function printTable(rows) {
     'multiBreath',
     'ampVar',
   ];
-  const colWidths = headers.map(h => Math.max(h.length, ...rows.map(r => String(r[h]).length)));
-  const sep = headers.map((h, i) => '-'.repeat(colWidths[i])).join('  ');
-  const headerRow = headers.map((h, i) => h.padEnd(colWidths[i])).join('  ');
-  console.log(headerRow);
-  console.log(sep);
-  for (const row of rows) {
-    const line = headers.map((h, i) => String(row[h]).padEnd(colWidths[i])).join('  ');
-    console.log(line);
-  }
-}
+  const colWidths = headers.map(h => h.length);
+  printHeader(headers, colWidths);
 
-async function main() {
-  const baseDir = process.argv[2] || path.join(__dirname, '..', 'DATALOG');
-  const files = findEdfFiles(baseDir);
-  if (files.length === 0) {
-    console.log('No EDF files found in', baseDir);
-    return;
-  }
-  const rows = [];
   for (const file of files) {
     try {
-      rows.push(await processFile(file));
+      const row = await processFile(file);
+      printRow(row, headers, colWidths);
     } catch (err) {
       console.error('Failed to process', file, '-', err.message);
     }
   }
-  printTable(rows);
 }
 
 if (require.main === module) {

--- a/cli/processDatalog.js
+++ b/cli/processDatalog.js
@@ -43,8 +43,14 @@ function findEdfFiles(dir) {
   const out = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const p = path.join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...findEdfFiles(p));
-    else if (entry.isFile() && entry.name.toLowerCase().endsWith('.edf')) out.push(p);
+    if (entry.isDirectory()) {
+      out.push(...findEdfFiles(p));
+    } else if (
+      entry.isFile() &&
+      entry.name.toLowerCase().endsWith('_brp.edf')
+    ) {
+      out.push(p);
+    }
   }
   return out;
 }
@@ -75,7 +81,7 @@ function printTable(rows) {
 }
 
 function main() {
-  const baseDir = path.join(__dirname, '..', 'DATALOG');
+  const baseDir = process.argv[2] || path.join(__dirname, '..', 'DATALOG');
   const files = findEdfFiles(baseDir);
   if (files.length === 0) {
     console.log('No EDF files found in', baseDir);

--- a/cli/processDatalog.js
+++ b/cli/processDatalog.js
@@ -61,6 +61,20 @@ function findEdfFiles(dir) {
   return out;
 }
 
+function extractDateFromPath(filePath) {
+  const base = path.basename(filePath).toLowerCase();
+  const match = base.match(/(\d{8})_(\d{6})_brp\.edf$/);
+  if (!match) return new Date(0);
+  const [_, d, t] = match;
+  const year = Number(d.slice(0, 4));
+  const month = Number(d.slice(4, 6)) - 1;
+  const day = Number(d.slice(6, 8));
+  const hour = Number(t.slice(0, 2));
+  const min = Number(t.slice(2, 4));
+  const sec = Number(t.slice(4, 6));
+  return new Date(Date.UTC(year, month, day, hour, min, sec));
+}
+
 
 function printHeader(headers, colWidths) {
   const headerRow = headers.map((h, i) => h.padEnd(colWidths[i])).join('  ');
@@ -79,6 +93,8 @@ function printRow(row, headers, colWidths) {
 async function main() {
   const baseDir = process.argv[2] || path.join(__dirname, '..', 'DATALOG');
   const files = findEdfFiles(baseDir);
+  // sort by date descending so newer files are processed first
+  files.sort((a, b) => extractDateFromPath(b) - extractDateFromPath(a));
   if (files.length === 0) {
     console.log('No EDF files found in', baseDir);
     return;

--- a/cli/processDatalog.js
+++ b/cli/processDatalog.js
@@ -1,0 +1,90 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadScript(file) {
+  const code = fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+  const context = { console };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  return context;
+}
+
+const edfCtx = loadScript('EDFFile.js');
+const flowCtx = loadScript('FlowLimits.js');
+
+const parseEDFFile = edfCtx.parseEDFFile;
+const {
+  formDataArray,
+  findMins,
+  findInspirations,
+  calcCycleBasedIndicators,
+  inspirationAmplitude,
+  prepIndices,
+} = flowCtx;
+
+function processFile(filePath) {
+  const buf = fs.readFileSync(filePath);
+  const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  const fileData = parseEDFFile(ab);
+  const dataArray = formDataArray(fileData);
+  findMins(dataArray);
+  const results = {};
+  findInspirations(dataArray, results);
+  calcCycleBasedIndicators(dataArray, results);
+  inspirationAmplitude(dataArray, results);
+  const indices = prepIndices(results);
+  const date = fileData.startDateTime.toISOString().slice(0, 10);
+  return { date, ...indices };
+}
+
+function findEdfFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...findEdfFiles(p));
+    else if (entry.isFile() && entry.name.toLowerCase().endsWith('.edf')) out.push(p);
+  }
+  return out;
+}
+
+function printTable(rows) {
+  const headers = [
+    'date',
+    'overall',
+    'skew',
+    'flatTop',
+    'spike',
+    'topHeavy',
+    'multiPeak',
+    'noPause',
+    'inspirRate',
+    'multiBreath',
+    'ampVar',
+  ];
+  const colWidths = headers.map(h => Math.max(h.length, ...rows.map(r => String(r[h]).length)));
+  const sep = headers.map((h, i) => '-'.repeat(colWidths[i])).join('  ');
+  const headerRow = headers.map((h, i) => h.padEnd(colWidths[i])).join('  ');
+  console.log(headerRow);
+  console.log(sep);
+  for (const row of rows) {
+    const line = headers.map((h, i) => String(row[h]).padEnd(colWidths[i])).join('  ');
+    console.log(line);
+  }
+}
+
+function main() {
+  const baseDir = path.join(__dirname, '..', 'DATALOG');
+  const files = findEdfFiles(baseDir);
+  if (files.length === 0) {
+    console.log('No EDF files found in', baseDir);
+    return;
+  }
+  const rows = files.map(processFile);
+  printTable(rows);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/cli/processDatalog.js
+++ b/cli/processDatalog.js
@@ -40,8 +40,10 @@ async function processFile(filePath) {
   calcCycleBasedIndicators(dataArray, results);
   inspirationAmplitude(dataArray, results);
   const indices = prepIndices(results);
-  const date = fileData.startDateTime.toISOString().slice(0, 10);
-  return { date, ...indices };
+  const dt = extractDateFromPath(filePath);
+  const date = dt.toISOString().slice(0, 10);
+  const time = dt.toISOString().slice(11, 19);
+  return { date, time, ...indices };
 }
 
 function findEdfFiles(dir) {
@@ -102,6 +104,7 @@ async function main() {
 
   const headers = [
     'date',
+    'time',
     'overall',
     'skew',
     'flatTop',


### PR DESCRIPTION
## Summary
- add a CLI script to process EDF files from `DATALOG`
- document usage in new README

## Testing
- `node cli/processDatalog.js`

------
https://chatgpt.com/codex/tasks/task_e_6858857c4710832f95752c45583d55a6