### PR TITLE
Support batch EDF uploads

### DIFF
--- a/FlowLimits.html
+++ b/FlowLimits.html
@@ -17,7 +17,7 @@
 		<span style="padding-left:100px;">For Sleep Disordered Breathing / Flow Limitations</span>
 		<span style="padding-left:100px;">(See <a href="Intro.html">introduction</a>)</span>
 	</div>
-	<p>Select file (Resmed "*DATE*_*TIME*_BRP.edf"): <input type="file" name="inputfile" id="fileInput" style="padding-left:40px;"></p>
+        <p>Select folder or files containing Resmed "*DATE*_*TIME*_BRP.edf": <input type="file" name="inputfile" id="fileInput" multiple webkitdirectory directory style="padding-left:40px;"></p>
 	<div>
   		<canvas id="chartTop"></canvas>
 	</div>
@@ -49,16 +49,7 @@ document.getElementById('fwdBtn').addEventListener('click', function (event) {
 });
 
 document.getElementById('fileInput').addEventListener('change', function (event) {
-	let file = event.target.files[0];
-    let reader = new FileReader();
-	
-   	reader.onload = function (event) {
-        	let arrayBuffer = event.target.result;
-        	dataArray=null;
-        	results = {};
-        	acceptFile(arrayBuffer);
-	}
-	reader.readAsArrayBuffer(file);    
+        queueEDFFileProcessing(event.target.files);
     }
 );
 

--- a/FlowLimits.js
+++ b/FlowLimits.js
@@ -21,7 +21,38 @@ const BLACK_COLOUR = "#000000";
 const MIN_WINDOW = 25;
 const GREY_ZONE_LOWER = -10;
 
-// Look for maximum negative (expiration) flow 
+function readFileAsArrayBuffer(file) {
+        return new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onload = (event) => resolve(event.target.result);
+                reader.onerror = () => reject(reader.error);
+                reader.readAsArrayBuffer(file);
+        });
+}
+
+async function queueEDFFileProcessing(fileList) {
+        if (!fileList || fileList.length === 0) {
+                return;
+        }
+
+        const edfFiles = Array.from(fileList).filter((file) => /_BRP\.edf$/i.test(file.name));
+
+        if (edfFiles.length === 0) {
+                alert('No files matching "*_BRP.edf" were found in the selected input.');
+                return;
+        }
+
+        for (const file of edfFiles) {
+                try {
+                        const arrayBuffer = await readFileAsArrayBuffer(file);
+                        acceptFile(arrayBuffer);
+                } catch (error) {
+                        console.error('Error reading file', file.name, error);
+                }
+        }
+}
+
+// Look for maximum negative (expiration) flow
 function findMins(dataArray){
 	for (let ptr = 0; ptr < (MIN_WINDOW) ; ptr++){
 // ignore first MIN_WINDOW samples (1 seconds worth)


### PR DESCRIPTION
## Summary
- allow selecting folders or multiple files for ResMed BRP EDF imports
- process only matching EDF files sequentially via a promise-based FileReader helper
- route selected files through the existing analysis pipeline for each accepted upload

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2f5f5731c83318326cb3472ce634c